### PR TITLE
Fix build error on MySQL version >= 8.0.1 

### DIFF
--- a/src/server/database/Database/DatabaseEnv.h
+++ b/src/server/database/Database/DatabaseEnv.h
@@ -27,6 +27,12 @@
 
 #include "Database/Database.h"
 typedef Database DatabaseType;
+
+// After version 8.01 my_bool is replaced with bool
+#if MYSQL_VERSION_ID >= 80001
+    typedef bool my_bool;
+#endif
+
 #define _LIKE_           "LIKE"
 #define _TABLE_SIM_      "`"
 #define _CONCAT3_(A,B,C) "CONCAT( " A " , " B " , " C " )"
@@ -37,4 +43,3 @@ extern DatabaseType CharacterDatabase;
 extern DatabaseType LoginDatabase;
 
 #endif
-


### PR DESCRIPTION
According to [this issue](https://bugs.mysql.com/bug.php?id=85131) in newer versions of MySQL `my_bool` has been removed, and replaced with `bool` type.
On Ubuntu 20.04 OregonCore doesn't compile with the latest packages without this fix.

Can someone check if it brakes anything on previous versions of Ubuntu? I can check Windows in a few hours and report back.