### PR TITLE
Remove obsolete SetGridId function

### DIFF
--- a/src/framework/GameSystem/NGrid.h
+++ b/src/framework/GameSystem/NGrid.h
@@ -95,7 +95,6 @@ class NGrid
         }
 
         uint32 GetGridId(void) const { return i_gridId; }
-        void SetGridId(const uint32 id) const { i_gridId = id; }
         grid_state_t GetGridState(void) const { return i_cellstate; }
         void SetGridState(grid_state_t s) { i_cellstate = s; }
         int32 getX() const { return i_x; }


### PR DESCRIPTION
The definition of the obsolete SetGridId function:

    void SetGridId(const uint32 id) const { i_gridId = id; }

breaks the build on recent compilers (clang12 on archlinux):

    In file included from /home/user/oregoncore/server/src/server/game/Grids/GridDefines.h:22:
    /home/user/oregoncore/server/src/framework/GameSystem/NGrid.h:98:58: error: cannot assign to non-static data member within const member function 'SetGridId'
            void SetGridId(const uint32 id) const { i_gridId = id; }
                                                    ~~~~~~~~ ^
    /home/user/oregoncore/server/src/framework/GameSystem/NGrid.h:98:14: note: member function 'NGrid::SetGridId' is declared const here
            void SetGridId(const uint32 id) const { i_gridId = id; }
            ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    1 error generated.

However, "SetGridId" is not used anywhere:

    $ grep -r "SetGridId" .
    ./src/framework/GameSystem/NGrid.h:        void SetGridId(const uint32 id) const { i_gridId = id; }

This PR removes the obsolete SetGridId function, and by this also fixes the build.