### PR TITLE
Remove Cornish Rex from Coldridge Valley

### DIFF
--- a/sql/updates/world/2021_06_18_remove_cornish_rex_cat.sql
+++ b/sql/updates/world/2021_06_18_remove_cornish_rex_cat.sql
@@ -1,0 +1,2 @@
+-- Remove Cornish Rex Cat in Coldridge Valley
+DELETE FROM `creature` WHERE `guid`= 1528 and `id`= 7384;


### PR DESCRIPTION
The [cat](https://classic.wowhead.com/npc=7384/cornish-rex) is not supposed to be there. 